### PR TITLE
fix(timecorrection): increase timeout

### DIFF
--- a/cypress/integration/timecorrection.spec.js
+++ b/cypress/integration/timecorrection.spec.js
@@ -31,7 +31,7 @@ context('PersonalWolke', () => {
         .type(description)
       cy.get('#wf_startRequest_button')
         .click()
-      cy.url()
+      cy.url({ timeout: 15000 })
         .should('include','https://personalwolke.at/webdesk3/wf_getMyOpenRequests.act')
 
     })


### PR DESCRIPTION
In some cases, cypress's default 4 seconds timeout is not enough for PersonalWolke to process your request and it shows as a failed test, this increase of timeout intends to overcome this issue.