### PR TITLE
feat(approve): automate approval of requests for managers

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,15 @@ nvm use
 npm run booking
 ```
 
+## Approve (For Managers)
+If you're managing a team with this you can automate the approval of the requests of your team members.
+Up to a 100 at a time, so you might need to run this multiple times if you're dealing with a huge team stacked up a lot to approve.
+
+```bash
+nvm use
+npm run approve
+```
+
 ## Debug/more fun
 If you wanna see how cypress made your time correction you can run the electron app
 

--- a/cypress/e2e/approve.cy.js
+++ b/cypress/e2e/approve.cy.js
@@ -1,0 +1,43 @@
+context('PersonalWolke', () => {
+  beforeEach(() => {
+    cy.visit('https://personalwolke.at/webdesk3/login')
+
+    cy.get('[name="userid"]').type(Cypress.env('username'))
+    cy.get('[name="password"]').type(Cypress.env('password'), {log: false})
+    cy.get('.login-buttons .btn').click()
+  })
+
+  it(`Approve`, () => {
+    cy.visit(`https://personalwolke.at/webdesk3/wf_getMyToDos.act`)
+    
+    cy.intercept('/webdesk3/wf_getMyToDos*').as('fetchTodoList')
+
+    cy.get('body').then((body) => {
+      if (!body.find(`#numberOfRows`).length)
+        return
+
+      cy.get(`#numberOfRows`)
+          .select('100')
+
+      // I'm not sure why do we need it two times, but it doesn't work otherwise...
+      cy.wait('@fetchTodoList', { timeout: 15000 })
+      cy.wait('@fetchTodoList', { timeout: 15000 })
+      cy.wait(1000)
+    });
+
+    const checkboxSelector = `input[name*='doApprove']`;
+    // const checkboxSelector = "input[name*='doDelete']";
+
+    cy.get('body').then((body) => {
+      if (!body.find(checkboxSelector).length)
+        return
+      
+      cy.get(checkboxSelector).check()
+      cy.get('#buttonWflistDoBatchProcessing').click()
+
+      cy.wait(15000)
+    })
+
+    cy.get(checkboxSelector).should('not.exist')
+  })
+})

--- a/package.json
+++ b/package.json
@@ -11,7 +11,8 @@
   },
   "scripts": {
     "debug": "cypress open",
-    "booking": "cypress run"
+    "booking": "cypress run --spec \"./cypress/e2e/timecorrection.cy.js\"",
+    "approve": "cypress run --spec \"./cypress/e2e/approve.cy.js\""
   },
   "author": "",
   "license": "ISC"


### PR DESCRIPTION
If you're managing a team with this you can automate the approval of the requests of your team members.

Up to 100 at a time, so you might need to run this multiple times if you're dealing with a huge team stacked up a lot to approve.

It's safe to run as a team member as there will be nothing to approve, but to avoid accidental runs, I separated the `npm run booking` and `npm run approve` commands.